### PR TITLE
fix: Remove invalid pipe operator in workflow YAML

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -47,12 +47,15 @@ jobs:
           
           if [[ "$LABELS" == *"major"* ]]; then
             echo "bump_type=major" >> "$GITHUB_OUTPUT"
+            echo "bump_type_upper=MAJOR" >> "$GITHUB_OUTPUT"
             echo "Version bump: MAJOR"
           elif [[ "$LABELS" == *"minor"* ]]; then
             echo "bump_type=minor" >> "$GITHUB_OUTPUT"
+            echo "bump_type_upper=MINOR" >> "$GITHUB_OUTPUT"
             echo "Version bump: MINOR"
           else
             echo "bump_type=patch" >> "$GITHUB_OUTPUT"
+            echo "bump_type_upper=PATCH" >> "$GITHUB_OUTPUT"
             echo "Version bump: PATCH (default)"
           fi
 
@@ -116,7 +119,7 @@ jobs:
 
             **PR Title:** ${{ github.event.pull_request.title }}
 
-            **Version Bump:** ${{ steps.version_type.outputs.bump_type | upper }}
+            **Version Bump:** ${{ steps.version_type.outputs.bump_type_upper }}
 
             **Merged by:** @${{ github.event.pull_request.merged_by.login }}
             


### PR DESCRIPTION
## Problem
The version-bump workflow had invalid syntax using `| upper` filter which is not supported in GitHub Actions expressions.

## Solution
- Added `bump_type_upper` output to the version determination step
- Replaced the invalid pipe operator with direct reference to the uppercase output

## Changes
- Fixed workflow YAML syntax error
- Version bump type now properly displays in uppercase in release notes

## Testing
- [x] YAML syntax is now valid
- [x] Pre-commit hooks pass

This fixes the workflow validation error that was preventing the version-bump automation from working correctly.