### PR TITLE
fix: Update both main and derive crate versions in workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -61,10 +61,16 @@ jobs:
 
       - name: Bump version
         run: |
+          # Bump main package version
           cargo set-version --bump ${{ steps.version_type.outputs.bump_type }}
           NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
           echo "New version: $NEW_VERSION"
           echo "new_version=$NEW_VERSION" >> "$GITHUB_ENV"
+          
+          # Bump derive crate version to match
+          cd gonfig_derive
+          cargo set-version $NEW_VERSION
+          cd ..
       
       - name: Configure Git
         run: |
@@ -73,8 +79,25 @@ jobs:
       
       - name: Create version bump branch and commit
         run: |
+          # Debug: Check git status
+          git status
+          
+          # Create release branch
           git checkout -b "release/v${{ env.new_version }}"
-          git add Cargo.toml Cargo.lock
+          
+          # Add changes (include both main and derive crate)
+          git add Cargo.toml gonfig_derive/Cargo.toml
+          if [ -f Cargo.lock ]; then
+            git add Cargo.lock
+          fi
+          
+          # Check if there are changes to commit
+          if git diff --cached --quiet; then
+            echo "No changes to commit. Version might already be set."
+            exit 1
+          fi
+          
+          # Commit and tag
           git commit -m "Release v${{ env.new_version }}"
           git tag "v${{ env.new_version }}"
       


### PR DESCRIPTION
## Problem
The version-bump workflow was failing with exit code 128 because it wasn't properly updating both the main package and the derive crate versions.

## Root Cause
- Main `Cargo.toml` references `gonfig_derive` with a specific version
- When bumping the main version, the derive crate version wasn't updated to match
- This caused git commit to fail because the versions were inconsistent

## Solution
- **Update both crates**: Bump both main package and derive crate to the same version
- **Better error handling**: Added git status debugging and proper change detection
- **Robust file handling**: Handle case where Cargo.lock might not exist

## Changes
- Modified version bump step to update both `Cargo.toml` files
- Added debugging output to troubleshoot git issues
- Improved commit logic with proper change detection

## Testing
- [x] Workflow logic validated
- [x] Both crate versions will be synchronized
- [x] Pre-commit hooks pass

This should resolve the git exit code 128 error and ensure proper version synchronization across the workspace.