### PR TITLE
bump: Update both crates to version 0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "gonfig"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "clap",
  "gonfig_derive",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "gonfig_derive"
-version = "0.1.2"
+version = "0.1.5"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gonfig"
-version = "0.1.3"
+version = "0.1.5"
 edition = "2021"
 authors = ["Vasanthkumar Kalaiselvan<itsparser@gmail.com>"]
 description = "A unified configuration management library for Rust that seamlessly integrates environment variables, config files, and CLI arguments"
@@ -24,7 +24,7 @@ once_cell = "1.19"
 tracing = "0.1"
 
 [dependencies.gonfig_derive]
-version = "0.1.2"
+version = "0.1.5"
 path = "gonfig_derive"
 
 [dev-dependencies]

--- a/gonfig_derive/Cargo.toml
+++ b/gonfig_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gonfig_derive"
-version = "0.1.2"
+version = "0.1.5"
 edition = "2021"
 authors = ["Vasanthkumar Kalaiselvan<itsparser@gmail.com>"]
 description = "Derive macros for the gonfig configuration management library"


### PR DESCRIPTION
## Summary
Synchronized version update for both main crate and derive crate to 0.1.5

## Changes
- Updated `Cargo.toml` version to 0.1.5
- Updated `gonfig_derive/Cargo.toml` version to 0.1.5  
- Updated dependency reference to match new derive crate version
- Updated `Cargo.lock` with new version constraints

## Testing
- [x] All tests pass
- [x] Both crates compile successfully
- [x] Pre-commit hooks validated
- [x] Derive macro dependency properly resolved

This update ensures version consistency across the workspace and tests our improved version-bump workflow.