### PR TITLE
fix: Handle existing tags gracefully in workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -97,9 +97,13 @@ jobs:
             exit 1
           fi
           
-          # Commit and tag
+          # Commit and tag (only if tag doesn't exist)
           git commit -m "Release v${{ env.new_version }}"
-          git tag "v${{ env.new_version }}"
+          if git rev-parse "v${{ env.new_version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ env.new_version }} already exists, skipping tag creation"
+          else
+            git tag "v${{ env.new_version }}"
+          fi
       
       - name: Build release artifacts
         run: |


### PR DESCRIPTION
## Problem
The version-bump workflow was failing because git tag creation failed when the tag already existed from a previous partial run.

## Root Cause
- When a workflow run fails partway through, it might have already created the git tag
- Subsequent workflow runs would fail when trying to create the same tag again
- This creates a loop where the workflow can't recover from partial failures

## Solution
- **Check tag existence**: Before creating a tag, check if it already exists
- **Skip gracefully**: If the tag exists, log a message and continue
- **Allow recovery**: This lets the workflow recover from previous partial failures

## Changes
- Added tag existence check using `git rev-parse`
- Only create tag if it doesn't already exist
- Added informative logging when skipping tag creation

## Testing
- [x] Workflow handles existing tags gracefully
- [x] Pre-commit hooks pass
- [x] Logic prevents duplicate tag errors

This fix ensures the version-bump workflow can recover from partial failures and continue processing releases correctly.