### PR TITLE
docs: Add comprehensive Gonfig derive macro documentation

### DIFF
--- a/gonfig_derive/src/lib.rs
+++ b/gonfig_derive/src/lib.rs
@@ -50,6 +50,153 @@ struct GonfigField {
     default: Option<String>,
 }
 
+/// Derive macro for automatic configuration management from environment variables, CLI arguments, and config files.
+///
+/// # Generated Methods
+///
+/// - `from_gonfig() -> Result<Self>` - Loads configuration from all enabled sources
+/// - `from_gonfig_with_builder(builder: ConfigBuilder) -> Result<Self>` - Uses custom builder for advanced configuration
+/// - `gonfig_builder() -> ConfigBuilder` - Returns a pre-configured builder
+///
+/// # Container Attributes
+///
+/// ## `#[Gonfig(env_prefix = "PREFIX")]`
+/// Prefixes environment variables with the given string. Fields are uppercased and appended.
+///
+/// ```rust,ignore
+/// #[derive(Gonfig, Deserialize)]
+/// #[Gonfig(env_prefix = "APP")]
+/// struct Config {
+///     database_url: String,  // Reads from APP_DATABASE_URL
+///     port: u16,             // Reads from APP_PORT
+/// }
+/// ```
+///
+/// ## `#[Gonfig(allow_cli)]`
+/// Enables CLI argument parsing with automatic kebab-case conversion.
+///
+/// ```rust,ignore
+/// #[derive(Gonfig, Deserialize)]
+/// #[Gonfig(allow_cli)]
+/// struct Config {
+///     max_connections: u32,  // CLI: --max-connections
+/// }
+/// ```
+///
+/// ## `#[Gonfig(allow_config)]`
+/// Automatically loads from `config.{toml,yaml,json}` in current directory.
+///
+/// ```rust,ignore
+/// #[derive(Gonfig, Deserialize)]
+/// #[Gonfig(allow_config)]
+/// struct Config {
+///     setting: String,  // Loaded from config file if present
+/// }
+/// ```
+///
+/// # Field Attributes
+///
+/// ## `#[gonfig(env_name = "CUSTOM_NAME")]`
+/// Overrides the environment variable name for a field.
+///
+/// ```rust,ignore
+/// #[derive(Gonfig, Deserialize)]
+/// #[Gonfig(env_prefix = "APP")]
+/// struct Config {
+///     #[gonfig(env_name = "DATABASE_CONNECTION_STRING")]
+///     database_url: String,  // Uses DATABASE_CONNECTION_STRING (not APP_DATABASE_URL)
+/// }
+/// ```
+///
+/// ## `#[gonfig(cli_name = "custom-name")]`
+/// Overrides the CLI argument name for a field.
+///
+/// ```rust,ignore
+/// #[derive(Gonfig, Deserialize)]
+/// #[Gonfig(allow_cli)]
+/// struct Config {
+///     #[gonfig(cli_name = "db-url")]
+///     database_url: String,  // CLI: --db-url (not --database-url)
+/// }
+/// ```
+///
+/// ## `#[gonfig(default = "value")]`
+/// Sets a default value (JSON-compatible string).
+///
+/// ```rust,ignore
+/// #[derive(Gonfig, Deserialize)]
+/// struct Config {
+///     #[gonfig(default = "8080")]
+///     port: u16,
+///
+///     #[gonfig(default = r#"["localhost"]"#)]
+///     allowed_hosts: Vec<String>,
+/// }
+/// ```
+///
+/// ## `#[skip]` or `#[skip_gonfig]`
+/// Excludes field from configuration loading.
+///
+/// ```rust,ignore
+/// #[derive(Gonfig, Deserialize)]
+/// struct Config {
+///     database_url: String,
+///
+///     #[skip]
+///     #[serde(skip)]
+///     runtime_data: Option<String>,  // Not loaded from config
+/// }
+/// ```
+///
+/// # Configuration Priority
+///
+/// Configuration sources are merged in the following priority order (later sources override earlier ones):
+///
+/// 1. Default values (from `#[gonfig(default)]` attributes)
+/// 2. Configuration files (if `allow_config` is set)
+/// 3. Environment variables (always enabled)
+/// 4. CLI arguments (if `allow_cli` is set)
+///
+/// # Complete Example
+///
+/// ```rust,ignore
+/// use gonfig::Gonfig;
+/// use serde::Deserialize;
+///
+/// #[derive(Debug, Deserialize, Gonfig)]
+/// #[Gonfig(env_prefix = "MYAPP", allow_cli, allow_config)]
+/// struct AppConfig {
+///     database_url: String,              // MYAPP_DATABASE_URL, --database-url
+///
+///     #[gonfig(default = "8080")]
+///     port: u16,                         // MYAPP_PORT, --port, default: 8080
+///
+///     #[gonfig(env_name = "LOG_LEVEL")]
+///     log_level: String,                 // LOG_LEVEL (custom name)
+///
+///     #[skip]
+///     #[serde(skip)]
+///     start_time: Option<std::time::Instant>,  // Runtime-only field
+/// }
+///
+/// fn main() -> gonfig::Result<()> {
+///     // Simple: loads from all enabled sources
+///     let config = AppConfig::from_gonfig()?;
+///
+///     // Advanced: custom builder with additional config file
+///     let mut builder = AppConfig::gonfig_builder();
+///     builder = builder.with_file("custom.toml")?;
+///     let config = AppConfig::from_gonfig_with_builder(builder)?;
+///
+///     Ok(())
+/// }
+/// ```
+///
+/// # Attribute Reference
+///
+/// - `Gonfig` - Container attribute for struct options (env_prefix, allow_cli, allow_config)
+/// - `gonfig` - Field attribute for customization (env_name, cli_name, default)
+/// - `skip` / `skip_gonfig` - Field attribute to exclude from configuration
 #[proc_macro_derive(Gonfig, attributes(gonfig, skip_gonfig, skip, Gonfig))]
 pub fn derive_gonfig(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -66,7 +213,6 @@ fn generate_gonfig_impl(opts: &GonfigOpts) -> proc_macro2::TokenStream {
     let name = &opts.ident;
     let (impl_generics, ty_generics, where_clause) = opts.generics.split_for_impl();
 
-    let allow_env = true; // Always enable environment variables by default
     let allow_cli = opts.allow_cli;
     let allow_config = opts.allow_config;
 
@@ -79,7 +225,6 @@ fn generate_gonfig_impl(opts: &GonfigOpts) -> proc_macro2::TokenStream {
         .expect("Only structs are supported")
         .fields;
 
-    // Separate regular fields from flattened fields
     let mut regular_mappings = Vec::new();
     let mut default_mappings = Vec::new();
 
@@ -87,40 +232,56 @@ fn generate_gonfig_impl(opts: &GonfigOpts) -> proc_macro2::TokenStream {
         let field_name = f.ident.as_ref().unwrap();
         let field_str = field_name.to_string();
 
-        // Note: flatten feature is not yet fully implemented
-        // For now, treat all fields as regular fields
-        {
-            // Generate expected environment variable name
-            let env_key = if let Some(custom_name) = &f.env_name {
-                // Use custom name directly if provided
-                custom_name.clone()
-            } else if !env_prefix.is_empty() {
-                // Use prefix + field name pattern
-                format!("{}_{}", env_prefix, field_str.to_uppercase())
+        // Generate environment variable name
+        let env_key = f.env_name.clone().unwrap_or_else(|| {
+            let upper = field_str.to_uppercase();
+            if env_prefix.is_empty() {
+                upper
             } else {
-                // Just field name in uppercase
-                field_str.to_uppercase()
-            };
-
-            // Generate CLI argument name (kebab-case)
-            let cli_key = if let Some(custom_name) = &f.cli_name {
-                custom_name.clone()
-            } else {
-                field_str.replace('_', "-")
-            };
-
-            regular_mappings.push(quote! {
-                (#field_str.to_string(), #env_key.to_string(), #cli_key.to_string())
-            });
-
-            // Handle default values
-            if let Some(default_value) = &f.default {
-                default_mappings.push(quote! {
-                    (#field_str.to_string(), #default_value.to_string())
-                });
+                format!("{env_prefix}_{upper}")
             }
+        });
+
+        // Generate CLI argument name
+        let cli_key = f
+            .cli_name
+            .clone()
+            .unwrap_or_else(|| field_str.replace('_', "-"));
+
+        regular_mappings.push(quote! {
+            (#field_str.to_string(), #env_key.to_string(), #cli_key.to_string())
+        });
+
+        // Handle default values
+        if let Some(default_value) = &f.default {
+            default_mappings.push(quote! {
+                (#field_str.to_string(), #default_value.to_string())
+            });
         }
     }
+
+    // Shared logic for configuring environment and CLI sources
+    let setup_env_cli = quote! {
+        let field_mappings: Vec<(String, String, String)> = vec![#(#regular_mappings),*];
+
+        // Environment is always enabled
+        let mut env = ::gonfig::Environment::new();
+        if !#env_prefix.is_empty() {
+            env = env.with_prefix(#env_prefix);
+        }
+        for (field_name, env_key, _) in &field_mappings {
+            env = env.with_field_mapping(field_name, env_key);
+        }
+        builder = builder.with_env_custom(env);
+
+        if #allow_cli {
+            let mut cli = ::gonfig::Cli::from_args();
+            for (field_name, _, cli_key) in &field_mappings {
+                cli = cli.with_field_mapping(field_name, cli_key);
+            }
+            builder = builder.with_cli_custom(cli);
+        }
+    };
 
     quote! {
         impl #impl_generics #name #ty_generics #where_clause {
@@ -129,67 +290,26 @@ fn generate_gonfig_impl(opts: &GonfigOpts) -> proc_macro2::TokenStream {
             }
 
             pub fn from_gonfig_with_builder(mut builder: ::gonfig::ConfigBuilder) -> ::gonfig::Result<Self> {
-                // Regular field mappings: (field_name, env_key, cli_key)
-                let field_mappings: Vec<(String, String, String)> = vec![#(#regular_mappings),*];
-
-                // Default value mappings: (field_name, default_value)
-                let default_values: Vec<(String, String)> = vec![#(#default_mappings),*];
-
-                if #allow_env {
-                    // Create custom environment source with field mappings
-                    let mut env = ::gonfig::Environment::new();
-
-                    if !#env_prefix.is_empty() {
-                        env = env.with_prefix(#env_prefix);
-                    }
-
-                    // Apply field-level mappings for regular fields
-                    for (field_name, env_key, _cli_key) in &field_mappings {
-                        env = env.with_field_mapping(field_name, env_key);
-                    }
-
-                    builder = builder.with_env_custom(env);
-                }
-
-                if #allow_cli {
-                    // Create custom CLI source with field mappings
-                    let mut cli = ::gonfig::Cli::from_args();
-
-                    // Apply field-level CLI mappings for regular fields
-                    for (field_name, _env_key, cli_key) in &field_mappings {
-                        cli = cli.with_field_mapping(field_name, cli_key);
-                    }
-
-                    builder = builder.with_cli_custom(cli);
-                }
+                #setup_env_cli
 
                 if #allow_config {
-                    // Config file support - check for default config files
                     use std::path::Path;
 
-                    if Path::new("config.toml").exists() {
-                        builder = match builder.with_file("config.toml") {
-                            Ok(b) => b,
-                            Err(e) => return Err(e),
-                        };
-                    } else if Path::new("config.yaml").exists() {
-                        builder = match builder.with_file("config.yaml") {
-                            Ok(b) => b,
-                            Err(e) => return Err(e),
-                        };
-                    } else if Path::new("config.json").exists() {
-                        builder = match builder.with_file("config.json") {
-                            Ok(b) => b,
-                            Err(e) => return Err(e),
-                        };
+                    // Try loading config files in order of preference
+                    let config_files = ["config.toml", "config.yaml", "config.json"];
+                    for config_file in config_files {
+                        if Path::new(config_file).exists() {
+                            builder = builder.with_file(config_file)?;
+                            break;
+                        }
                     }
                 }
 
                 // Apply default values
+                let default_values: Vec<(String, String)> = vec![#(#default_mappings),*];
                 if !default_values.is_empty() {
                     let mut defaults_json = ::serde_json::Map::new();
                     for (field_name, default_value) in default_values {
-                        // Try to parse as JSON first, otherwise use as string
                         let value = default_value.parse::<::serde_json::Value>()
                             .unwrap_or_else(|_| ::serde_json::Value::String(default_value));
                         defaults_json.insert(field_name, value);
@@ -197,48 +317,13 @@ fn generate_gonfig_impl(opts: &GonfigOpts) -> proc_macro2::TokenStream {
                     builder = builder.with_defaults(::serde_json::Value::Object(defaults_json))?;
                 }
 
-                // Build the final configuration with explicit type
                 builder.build::<Self>()
             }
 
             pub fn gonfig_builder() -> ::gonfig::ConfigBuilder {
                 let mut builder = ::gonfig::ConfigBuilder::new();
-
-                // Regular field mappings: (field_name, env_key, cli_key)
-                let field_mappings: Vec<(String, String, String)> = vec![#(#regular_mappings),*];
-
-                if #allow_env {
-                    // Create custom environment source with field mappings
-                    let mut env = ::gonfig::Environment::new();
-
-                    if !#env_prefix.is_empty() {
-                        env = env.with_prefix(#env_prefix);
-                    }
-
-                    // Apply field-level mappings for regular fields
-                    for (field_name, env_key, _cli_key) in &field_mappings {
-                        env = env.with_field_mapping(field_name, env_key);
-                    }
-
-                    builder = builder.with_env_custom(env);
-                }
-
-                if #allow_cli {
-                    // Create custom CLI source with field mappings
-                    let mut cli = ::gonfig::Cli::from_args();
-
-                    // Apply field-level CLI mappings for regular fields
-                    for (field_name, _env_key, cli_key) in &field_mappings {
-                        cli = cli.with_field_mapping(field_name, cli_key);
-                    }
-
-                    builder = builder.with_cli_custom(cli);
-                }
-
-                // Note: Config file loading and defaults are not supported in gonfig_builder()
-                // due to Result handling requirements. Use from_gonfig_with_builder() instead
-                // for full config file and default value support.
-
+                #setup_env_cli
+                // Note: Config file and defaults not supported here due to Result handling
                 builder
             }
         }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -413,7 +413,7 @@ impl ConfigBuilder {
         }
 
         serde_json::from_value(merged)
-            .map_err(|e| Error::Serialization(format!("Failed to deserialize config: {}", e)))
+            .map_err(|e| Error::Serialization(format!("Failed to deserialize config: {e}")))
     }
 
     pub fn build_value(self) -> Result<Value> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,7 @@ impl Cli {
         let app = T::parse();
 
         let json_value = serde_json::to_value(&app).map_err(|e| {
-            crate::error::Error::Serialization(format!("Failed to serialize clap args: {}", e))
+            crate::error::Error::Serialization(format!("Failed to serialize clap args: {e}"))
         })?;
 
         let mut parsed_values = HashMap::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,14 +93,14 @@ impl ConfigFormat {
     pub fn parse(&self, content: &str) -> Result<Value> {
         match self {
             ConfigFormat::Json => serde_json::from_str(content)
-                .map_err(|e| Error::Serialization(format!("JSON parse error: {}", e))),
+                .map_err(|e| Error::Serialization(format!("JSON parse error: {e}"))),
             ConfigFormat::Yaml => serde_yaml::from_str(content)
-                .map_err(|e| Error::Serialization(format!("YAML parse error: {}", e))),
+                .map_err(|e| Error::Serialization(format!("YAML parse error: {e}"))),
             ConfigFormat::Toml => {
                 let toml_value: toml::Value = toml::from_str(content)
-                    .map_err(|e| Error::Serialization(format!("TOML parse error: {}", e)))?;
+                    .map_err(|e| Error::Serialization(format!("TOML parse error: {e}")))?;
                 serde_json::to_value(toml_value).map_err(|e| {
-                    Error::Serialization(format!("TOML to JSON conversion error: {}", e))
+                    Error::Serialization(format!("TOML to JSON conversion error: {e}"))
                 })
             }
         }
@@ -165,7 +165,7 @@ impl Config {
             .extension()
             .and_then(|ext| ext.to_str())
             .and_then(ConfigFormat::from_extension)
-            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {:?}", path)))?;
+            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {path:?}")))?;
 
         let mut config = Self {
             path,
@@ -204,7 +204,7 @@ impl Config {
             .extension()
             .and_then(|ext| ext.to_str())
             .and_then(ConfigFormat::from_extension)
-            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {:?}", path)))?;
+            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {path:?}")))?;
 
         let path_display = path.display().to_string();
         let mut config = Self {


### PR DESCRIPTION
## Summary
- Add comprehensive rustdoc documentation for the Gonfig derive macro
- Simplify derive macro code generation
- Fix clippy warnings in core library files

## Changes

### Documentation (gonfig_derive/src/lib.rs)
Added 153 lines of comprehensive documentation including:
- **Generated Methods**: Overview of `from_gonfig()`, `from_gonfig_with_builder()`, and `gonfig_builder()`
- **Container Attributes**: Detailed docs for `env_prefix`, `allow_cli`, `allow_config`
- **Field Attributes**: Complete coverage of `env_name`, `cli_name`, `default`, `skip`/`skip_gonfig`
- **Configuration Priority**: Clear explanation of how sources are merged
- **Complete Example**: Real-world usage demonstrating all features

### Code Simplification
- **Extract shared logic**: Created reusable `setup_env_cli` code block to eliminate duplication between `from_gonfig_with_builder()` and `gonfig_builder()` methods
- **Simplify config file loading**: Replaced verbose if-else chain with clean loop over `["config.toml", "config.yaml", "config.json"]`
- **Clean up variable usage**: Removed unused `allow_env` variable (environment is always enabled)
- **Streamline environment key generation**: Simplified logic with cleaner pattern matching
- **Remove redundant comments**: Cleaned up unnecessary inline comments

### Code Quality
Fixed `clippy::uninlined_format_args` warnings in core library:
- `src/builder.rs`
- `src/cli.rs`
- `src/config.rs`

## Benefits
1. **Improved Developer Experience**: Comprehensive documentation helps users understand all available options
2. **Reduced Code Duplication**: Shared environment/CLI setup logic now in one place (~40 lines eliminated)
3. **Better Maintainability**: Future changes only need to be made once
4. **Cleaner Code Flow**: Simplified config file loading is easier to understand
5. **Modern Rust Style**: All format strings follow inline variable conventions

## Note on CI
This PR has clippy warnings in example files. These examples need the fixes from PR #15 to be merged first. The core library changes pass all checks.

## Test Plan
- [x] Documentation builds successfully
- [x] Core library clippy passes with `-D warnings`
- [x] All tests pass
- [x] No functional changes to derive macro behavior
- [x] Code simplification preserves exact same functionality