### PR TITLE
fix: Add nested mode for environment variable override of config files

### DIFF
--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -85,12 +85,12 @@ fn main() -> gonfig::Result<()> {
                 );
             }
         }
-        Err(e) => eprintln!("Configuration error: {}", e),
+        Err(e) => eprintln!("Configuration error: {e}"),
     }
     println!("\nRaw merged configuration:");
     match serde_json::to_string_pretty(&value) {
-        Ok(json_str) => println!("{}", json_str),
-        Err(e) => eprintln!("Failed to serialize to JSON: {}", e),
+        Ok(json_str) => println!("{json_str}"),
+        Err(e) => eprintln!("Failed to serialize to JSON: {e}"),
     }
 
     Ok(())

--- a/examples/comprehensive_skip.rs
+++ b/examples/comprehensive_skip.rs
@@ -97,7 +97,7 @@ fn main() -> gonfig::Result<()> {
             println!("   Runtime Connection: {:?}", config.runtime_connection);
             println!("   Internal Cache: {:?}", config.internal_cache);
         }
-        Err(e) => println!("❌ Error loading AppConfig: {}", e),
+        Err(e) => println!("❌ Error loading AppConfig: {e}"),
     }
 
     println!("\n2. Loading DatabaseConfig:");
@@ -115,7 +115,7 @@ fn main() -> gonfig::Result<()> {
             println!("\n   After setting password from secure vault:");
             println!("   Password: [SET FROM VAULT]");
         }
-        Err(e) => println!("❌ Error loading DatabaseConfig: {}", e),
+        Err(e) => println!("❌ Error loading DatabaseConfig: {e}"),
     }
 
     println!("\n3. Skip vs Include Comparison:");

--- a/examples/madara.rs
+++ b/examples/madara.rs
@@ -44,7 +44,7 @@ fn main() -> gonfig::Result<()> {
     std::env::set_var("MDR_SERVER_WORKERS", "4");
 
     let config = Madara::from_gonfig()?;
-    println!("Loaded config from environment: {:#?}", config);
+    println!("Loaded config from environment: {config:#?}");
 
     let builder = ConfigBuilder::new()
         .with_merge_strategy(MergeStrategy::Deep)
@@ -63,14 +63,14 @@ fn main() -> gonfig::Result<()> {
 
     match builder.build::<Madara>() {
         Ok(config) => {
-            println!("\nValidated config: {:#?}", config);
+            println!("\nValidated config: {config:#?}");
             println!("\nMongo URI: {}", config.mongo.uri);
             println!("Server: {}:{}", config.server.host, config.server.port);
             if let Some(workers) = config.server.worker_threads {
-                println!("Workers: {}", workers);
+                println!("Workers: {workers}");
             }
         }
-        Err(e) => eprintln!("Config error: {}", e),
+        Err(e) => eprintln!("Config error: {e}"),
     }
 
     Ok(())

--- a/examples/madara_usecase.rs
+++ b/examples/madara_usecase.rs
@@ -52,7 +52,7 @@ fn main() -> gonfig::Result<()> {
             println!("✅ Loaded config from environment:");
             print_madara_config(&config);
         }
-        Err(e) => println!("❌ Error: {}", e),
+        Err(e) => println!("❌ Error: {e}"),
     }
 
     println!("\n2. Loading with custom builder (advanced approach):");
@@ -104,14 +104,14 @@ fn main() -> gonfig::Result<()> {
             );
 
             if let Some(workers) = config.server.worker_threads {
-                println!("Worker Threads: {}", workers);
+                println!("Worker Threads: {workers}");
             }
 
             if let Some(timeout) = config.mongo.connection_timeout {
-                println!("Connection Timeout: {}s", timeout);
+                println!("Connection Timeout: {timeout}s");
             }
         }
-        Err(e) => println!("❌ Validation failed: {}", e),
+        Err(e) => println!("❌ Validation failed: {e}"),
     }
 
     println!("\n4. Testing different environment variable patterns:");
@@ -150,20 +150,20 @@ fn print_madara_config(config: &Madara) {
     println!("     URI: {}", config.mongo.uri);
     println!("     Database: {}", config.mongo.database);
     if let Some(timeout) = config.mongo.connection_timeout {
-        println!("     Timeout: {}s", timeout);
+        println!("     Timeout: {timeout}s");
     }
     if let Some(pool_size) = config.mongo.max_pool_size {
-        println!("     Pool Size: {}", pool_size);
+        println!("     Pool Size: {pool_size}");
     }
 
     println!("  🌐 Server:");
     println!("     Host: {}", config.server.host);
     println!("     Port: {}", config.server.port);
     if let Some(workers) = config.server.worker_threads {
-        println!("     Workers: {}", workers);
+        println!("     Workers: {workers}");
     }
     if let Some(cors) = config.server.enable_cors {
-        println!("     CORS: {}", cors);
+        println!("     CORS: {cors}");
     }
 }
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -27,7 +27,7 @@ fn main() -> gonfig::Result<()> {
             println!("Port: {}", config.port);
             println!("Debug: {}", config.debug);
         }
-        Err(e) => eprintln!("Error: {}", e),
+        Err(e) => eprintln!("Error: {e}"),
     }
 
     Ok(())

--- a/examples/skip_attributes.rs
+++ b/examples/skip_attributes.rs
@@ -90,7 +90,7 @@ fn main() -> gonfig::Result<()> {
             println!("\n2. After manual initialization of skipped fields:");
             print_app_config_with_skipped(&config);
         }
-        Err(e) => println!("❌ Error: {}", e),
+        Err(e) => println!("❌ Error: {e}"),
     }
 
     println!("\n3. Loading DatabaseConfig with selective skipping:");
@@ -107,7 +107,7 @@ fn main() -> gonfig::Result<()> {
             println!("   Password: [MANUALLY SET]");
             println!("   Pool: [MANUALLY INITIALIZED]");
         }
-        Err(e) => println!("❌ Database config error: {}", e),
+        Err(e) => println!("❌ Database config error: {e}"),
     }
 
     println!("\n4. Skip attribute use cases:");

--- a/examples/your_usecase.rs
+++ b/examples/your_usecase.rs
@@ -41,7 +41,7 @@ fn main() -> gonfig::Result<()> {
             println!("✅ Successfully loaded configuration:");
             print_config(&config);
         }
-        Err(e) => println!("❌ Error loading config: {}", e),
+        Err(e) => println!("❌ Error loading config: {e}"),
     }
 
     println!("\n2. Testing individual component loading:");
@@ -56,7 +56,7 @@ fn main() -> gonfig::Result<()> {
             println!("  Username: {}", mongo.username);
             println!("  Password: [REDACTED]");
         }
-        Err(e) => println!("  Error: {}", e),
+        Err(e) => println!("  Error: {e}"),
     }
 
     // Test Application component
@@ -67,7 +67,7 @@ fn main() -> gonfig::Result<()> {
             println!("  Password: [REDACTED]");
             println!("  Client: {:?} (skipped in gonfig)", app.client);
         }
-        Err(e) => println!("  Error: {}", e),
+        Err(e) => println!("  Error: {e}"),
     }
 
     println!("\n3. Environment variable mapping demonstration:");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -413,7 +413,7 @@ impl ConfigBuilder {
         }
 
         serde_json::from_value(merged)
-            .map_err(|e| Error::Serialization(format!("Failed to deserialize config: {}", e)))
+            .map_err(|e| Error::Serialization(format!("Failed to deserialize config: {e}")))
     }
 
     pub fn build_value(self) -> Result<Value> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,7 +62,7 @@ impl Cli {
         let app = T::parse();
 
         let json_value = serde_json::to_value(&app).map_err(|e| {
-            crate::error::Error::Serialization(format!("Failed to serialize clap args: {}", e))
+            crate::error::Error::Serialization(format!("Failed to serialize clap args: {e}"))
         })?;
 
         let mut parsed_values = HashMap::new();

--- a/src/config.rs
+++ b/src/config.rs
@@ -93,14 +93,14 @@ impl ConfigFormat {
     pub fn parse(&self, content: &str) -> Result<Value> {
         match self {
             ConfigFormat::Json => serde_json::from_str(content)
-                .map_err(|e| Error::Serialization(format!("JSON parse error: {}", e))),
+                .map_err(|e| Error::Serialization(format!("JSON parse error: {e}"))),
             ConfigFormat::Yaml => serde_yaml::from_str(content)
-                .map_err(|e| Error::Serialization(format!("YAML parse error: {}", e))),
+                .map_err(|e| Error::Serialization(format!("YAML parse error: {e}"))),
             ConfigFormat::Toml => {
                 let toml_value: toml::Value = toml::from_str(content)
-                    .map_err(|e| Error::Serialization(format!("TOML parse error: {}", e)))?;
+                    .map_err(|e| Error::Serialization(format!("TOML parse error: {e}")))?;
                 serde_json::to_value(toml_value).map_err(|e| {
-                    Error::Serialization(format!("TOML to JSON conversion error: {}", e))
+                    Error::Serialization(format!("TOML to JSON conversion error: {e}"))
                 })
             }
         }
@@ -165,7 +165,7 @@ impl Config {
             .extension()
             .and_then(|ext| ext.to_str())
             .and_then(ConfigFormat::from_extension)
-            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {:?}", path)))?;
+            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {path:?}")))?;
 
         let mut config = Self {
             path,
@@ -204,7 +204,7 @@ impl Config {
             .extension()
             .and_then(|ext| ext.to_str())
             .and_then(ConfigFormat::from_extension)
-            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {:?}", path)))?;
+            .ok_or_else(|| Error::Config(format!("Unknown config format for file: {path:?}")))?;
 
         let path_display = path.display().to_string();
         let mut config = Self {

--- a/tests/debug_env.rs
+++ b/tests/debug_env.rs
@@ -10,7 +10,7 @@ fn debug_environment_collection() {
     let env = Environment::new();
     let result = env.collect().unwrap();
 
-    println!("Collected environment: {:#?}", result);
+    println!("Collected environment: {result:#?}");
 
     // Clean up
     env::remove_var("DATABASE_URL");


### PR DESCRIPTION
## Summary
Fixes #18 - Environment variables now properly override nested config file values at any depth.

## Changes
- Added `nested: bool` field to `Environment` struct
- Added `.nested(bool)` method for opt-in nested key handling
- Implemented `insert_nested()` helper to convert flat env keys into nested JSON structures
- Environment variables with separators (e.g., `APP_HTTP_PORT`) are split into nested paths when `nested=true`

## Testing
- Added comprehensive test suite in `tests/issue_18_nested_env_override.rs` (4 tests for 2-level nesting)
- Added deep nesting validation in `tests/deep_nested_env_override.rs` (5 tests covering 4, 5, 6 levels)
- Created working examples: `examples/nested_env_override.rs` and `examples/deep_nested_example.rs`
- All 35 tests pass (26 existing + 9 new)

## Backward Compatibility
- Default behavior (`nested=false`) preserved
- Opt-in via `.nested(true)`
- No breaking changes

## Usage Example
\`\`\`rust
let config: Config = ConfigBuilder::new()
    .with_merge_strategy(MergeStrategy::Deep)
    .with_file("config.yaml")?
    .with_env_custom(Environment::new().with_prefix("APP").nested(true))
    .build()?;
\`\`\`

Now `APP_HTTP_PORT=9000` will properly override `http.port: 3000` from config file.